### PR TITLE
Enhancement: FFprobe Analysis & Segment Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ It follows **RFC-8216 (HLS standard)** to detect **errors and anomalies** in the
 
 - 📡 **Downloads `.m3u8` files** dynamically from a given URL.
 - 🔍 **Validates stream integrity** using **ChatGPT (GPT-3.5 Turbo)**.
+- 🛠️ Runs ffprobe on the .ts segment to verify stream properties.
 - ⚡ **Fast & Lightweight**, built with Java + Maven.
 - 🔐 **API Key Management** via `config.properties` or environment variables.
 - 📖 **Open Source** under **Apache License 2.0**.
@@ -66,6 +67,20 @@ export OPENAI_API_KEY="sk-your-api-key-here"
 ```
 
 (For Windows: use `set OPENAI_API_KEY="sk-your-api-key-here"` in CMD.)
+
+### 4️⃣ Install FFmpeg (Required for ffprobe)
+The tool requires ffprobe to analyze .ts media files.
+
+Install on macOS (via Homebrew):
+```sh
+brew install ffmpeg
+```
+Install on Ubuntu:
+```sh
+sudo apt update && sudo apt install ffmpeg
+```
+Install on Windows:
+Download from FFmpeg official site and add it to your system PATH.
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ai.hls-analyzer</groupId>
     <artifactId>hls-analyzer</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>HLS analyzer via ChatGPT API</name>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,41 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+
+        <!-- JUnit 5 -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.9.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Mockito for mocking -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.6.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>4.6.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Apache HttpComponents for fluent HTTP client -->
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.4.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/ChatGPTClient.java
+++ b/src/main/java/ChatGPTClient.java
@@ -1,25 +1,53 @@
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class ChatGPTClient {
   private static final String API_URL = "https://api.openai.com/v1/chat/completions";
   private static final String API_KEY = ConfigLoader.getProperty("openai.api.key");
 
-  public static String analyzeM3U8(String m3u8Content) throws Exception {
+  public static String analyzeM3U8(String m3u8Content, String m3u8Url) throws Exception {
     if (API_KEY == null || API_KEY.isEmpty()) {
       throw new IllegalStateException("OpenAI API key is missing in config.properties!");
     }
 
-    URL url = new URL(API_URL);
-    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-    conn.setRequestMethod("POST");
-    conn.setRequestProperty("Authorization", "Bearer " + API_KEY);
-    conn.setRequestProperty("Content-Type", "application/json");
-    conn.setDoOutput(true);
+    // Check if it's a master playlist and resolve to a variant playlist
+    System.out.println("Checking if M3U8 is a master playlist...");
+    String variantPlaylistUrl = extractFirstVariantPlaylist(m3u8Content, m3u8Url);
+    if (variantPlaylistUrl != null) {
+      System.out.println("Master playlist detected. Fetching variant playlist: " + variantPlaylistUrl);
+      m3u8Content = M3U8Downloader.downloadM3U8(variantPlaylistUrl);
+      m3u8Url = variantPlaylistUrl;
+    }
+
+    // Extract first TS segment
+    System.out.println("Extracting first .ts segment from M3U8...");
+    String tsUrl = extractFirstTsSegment(m3u8Content, m3u8Url);
+    if (tsUrl == null) {
+      throw new IllegalStateException("No .ts segment found in M3U8 playlist.");
+    }
+
+    System.out.println("Downloading .ts segment: " + tsUrl);
+    File tsFile = downloadTsSegment(tsUrl);
+    System.out.println("Download complete: " + tsFile.getAbsolutePath());
+
+    System.out.println("Running ffprobe on .ts segment...");
+    String ffprobeOutput = runFfprobe(tsFile);
+    System.out.println("FFprobe analysis complete.");
+    System.out.println("FFprobe output:\n" + ffprobeOutput);
 
     // Custom Instructions for ChatGPT
     String customInstructions =
@@ -27,32 +55,112 @@ public class ChatGPTClient {
             "You have to analyze streaming files and find all sorts of anomalies. " +
             "Use standard RFC-8216 for validation.\n\n" +
             "If you do not find anomalies, then I expect a response:\n" +
-            "{\"status\": \"OK\", \"message\": \"Manifest is correct\"}\n" +
+            "{\"status\": \"OK\", \"message\": \"Manifest and media file are correct\"}\n" +
             "If you found anomalies, then I expect a response:\n" +
-            "{\"status\": \"FAIL\", \"message\": \"[Add here information about what is wrong in a stream in 200 symbols]\"}";
+            "{\"status\": \"FAIL\", \"message\": \"[Describe issues in 200 characters]\"}";
 
     // JSON payload for ChatGPT API
     Map<String, Object> data = new HashMap<>();
     data.put("model", "gpt-3.5-turbo");
-    data.put("messages", new Object[]{
-        new HashMap<String, String>() {{
-          put("role", "system");
-          put("content", customInstructions);
-        }},
-        new HashMap<String, String>() {{
-          put("role", "user");
-          put("content", m3u8Content);
-        }}
-    });
+
+    List<Map<String, String>> messages = new ArrayList<>();
+
+    Map<String, String> systemMessage = new HashMap<>();
+    systemMessage.put("role", "system");
+    systemMessage.put("content", customInstructions);
+    messages.add(systemMessage);
+
+    Map<String, String> userMessage = new HashMap<>();
+    userMessage.put("role", "user");
+    userMessage.put("content", "M3U8 Playlist:\n" + m3u8Content + "\n\nFFprobe Output:\n" + ffprobeOutput);
+    messages.add(userMessage);
+
+    data.put("messages", messages);
 
     // Convert to JSON
     ObjectMapper mapper = new ObjectMapper();
     String jsonPayload = mapper.writeValueAsString(data);
 
+    System.out.println("Sending request to ChatGPT...");
+    URL url = new URL(API_URL);
+    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    conn.setRequestMethod("POST");
+    conn.setRequestProperty("Authorization", "Bearer " + API_KEY);
+    conn.setRequestProperty("Content-Type", "application/json");
+    conn.setDoOutput(true);
+
     try (OutputStream os = conn.getOutputStream()) {
       os.write(jsonPayload.getBytes());
     }
 
-    return new String(conn.getInputStream().readAllBytes());
+    String response = new String(conn.getInputStream().readAllBytes());
+    System.out.println("Received response from ChatGPT.");
+    return response;
+  }
+
+  private static String extractFirstVariantPlaylist(String m3u8Content, String m3u8Url) {
+    Pattern pattern = Pattern.compile("([^#][^\\s]+\\.m3u8)");
+    Matcher matcher = pattern.matcher(m3u8Content);
+
+    if (matcher.find()) {
+      String variantPlaylist = matcher.group(1);
+      if (!variantPlaylist.startsWith("http")) {
+        return resolveM3U8Url(m3u8Url, variantPlaylist);
+      }
+      return variantPlaylist;
+    }
+    return null;
+  }
+
+  private static String extractFirstTsSegment(String m3u8Content, String m3u8Url) {
+    Pattern pattern = Pattern.compile("([^#][^\\s]+\\.ts)");
+    Matcher matcher = pattern.matcher(m3u8Content);
+
+    if (matcher.find()) {
+      String tsSegment = matcher.group(1);
+      if (!tsSegment.startsWith("http")) {
+        return resolveM3U8Url(m3u8Url, tsSegment);
+      }
+      return tsSegment;
+    }
+    return null;
+  }
+
+  private static String resolveM3U8Url(String m3u8Url, String relativePath) {
+    try {
+      URL url = new URL(m3u8Url);
+      return new URL(url, relativePath).toString();
+    } catch (Exception e) {
+      System.err.println("Error resolving URL: " + e.getMessage());
+      return null;
+    }
+  }
+
+  private static File downloadTsSegment(String tsUrl) throws IOException {
+    File tempFile = File.createTempFile("segment", ".ts");
+    try (BufferedInputStream in = new BufferedInputStream(new URL(tsUrl).openStream());
+         FileOutputStream fileOutputStream = new FileOutputStream(tempFile)) {
+      byte[] dataBuffer = new byte[1024];
+      int bytesRead;
+      while ((bytesRead = in.read(dataBuffer, 0, 1024)) != -1) {
+        fileOutputStream.write(dataBuffer, 0, bytesRead);
+      }
+    }
+    return tempFile;
+  }
+
+  private static String runFfprobe(File tsFile) throws IOException {
+    ProcessBuilder pb = new ProcessBuilder(
+        "ffprobe", "-v", "error", "-show_format", "-show_streams", "-print_format", "json", tsFile.getAbsolutePath());
+    Process process = pb.start();
+
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+      StringBuilder output = new StringBuilder();
+      String line;
+      while ((line = reader.readLine()) != null) {
+        output.append(line).append("\n");
+      }
+      return output.toString();
+    }
   }
 }

--- a/src/main/java/HLSAnalyzer.java
+++ b/src/main/java/HLSAnalyzer.java
@@ -9,8 +9,8 @@ public class HLSAnalyzer {
       System.out.println("M3U8 downloaded successfully!");
 
       System.out.println("Sending to ChatGPT for analysis...");
-      String response = ChatGPTClient.analyzeM3U8(m3u8Content);
-      System.out.println("ChatGPT Response: \n" + response);
+      String response = ChatGPTClient.analyzeM3U8(m3u8Content, streamUrl);
+      System.out.println("ChatGPT Response:\n" + response);
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/src/test/java/M3U8DownloaderTest.java
+++ b/src/test/java/M3U8DownloaderTest.java
@@ -1,0 +1,59 @@
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import org.apache.hc.client5.http.fluent.Request;
+import org.apache.hc.client5.http.fluent.Response;
+import org.junit.jupiter.api.Test;
+
+public class M3U8DownloaderTest {
+
+  @Test
+  void testDownloadValidM3U8() throws Exception {
+    // Simulated M3U8 content
+    String mockM3U8Content = "#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1280000\nvideo.m3u8";
+
+    // Mock Content
+    org.apache.hc.client5.http.fluent.Content mockContent = mock(org.apache.hc.client5.http.fluent.Content.class);
+    when(mockContent.asString()).thenReturn(mockM3U8Content); // Mock `asString()`
+
+    // Mock Response
+    Response mockResponse = mock(Response.class);
+    when(mockResponse.returnContent()).thenReturn(mockContent);
+
+    // Mock Request
+    Request mockRequest = mock(Request.class);
+    when(mockRequest.execute()).thenReturn(mockResponse);
+
+    // Call the actual method
+    String content = M3U8Downloader.downloadM3U8("https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8");
+
+    // Validate the response
+    assertNotNull(content, "Downloaded content should not be null");
+    assertTrue(content.contains("#EXTM3U"), "Content should contain M3U8 header");
+  }
+
+  @Test
+  void testDownloadInvalidURL() {
+    String invalidUrl = "invalid-url";
+    assertThrows(IOException.class, () -> M3U8Downloader.downloadM3U8(invalidUrl),
+        "Should throw IOException for invalid URL");
+  }
+
+  @Test
+  void testHttpErrorResponse() throws Exception {
+    // Mock request and response
+    Response mockResponse = mock(Response.class);
+    when(mockResponse.returnContent()).thenThrow(new IOException("Internal Server Error"));
+
+    Request mockRequest = mock(Request.class);
+    when(mockRequest.execute()).thenReturn(mockResponse);
+
+    // Expect exception when calling M3U8Downloader
+    assertThrows(IOException.class, () -> M3U8Downloader.downloadM3U8("https://example.com/error.m3u8"),
+        "Should throw IOException on HTTP error");
+  }
+}


### PR DESCRIPTION
This PR enhances the HLS Analyzer by adding FFprobe analysis and segment validation before sending data to ChatGPT for verification.

**Key Changes:**
✅ Extract & Download .ts Segment

- Parses the .m3u8 file to locate the media segment
- Handles master playlists by selecting an appropriate variant

✅ Run ffprobe on .ts Segment

- Extracts metadata like codec, bitrate, resolution, and duration
- Ensures the segment matches the declared stream properties

✅ Send Extended Data to ChatGPT

- Includes both the .m3u8 manifest and FFprobe output
- Enhances anomaly detection with detailed media validation